### PR TITLE
feature/8 trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ HttpServer::new(|| App::new().wrap(Logger::default()).configure(routes::routes))
     .await
 ``` 
 
+### NormalizePath
+リクエストパスの正規化処理を [app/mod.rs](./src/app/mod.rs) に追加。
+Trailing slash なしに寄せたい場合は自作する必要がありそう。
+
+```rust
+App::new()
+    .wrap(Logger::default())
+    .configure(routes::routes)
+    .wrap(middleware::NormalizePath)
+```
+
 ## Endpoints
 
 ### [[GET] /api/articles](./src/app/v1/articles/handler/articles_handler.rs)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,5 @@
 use actix_web::middleware::Logger;
-use actix_web::{App, HttpServer};
+use actix_web::{middleware, App, HttpServer};
 use env_logger::Env;
 
 mod routes;
@@ -8,8 +8,13 @@ mod v1;
 pub(crate) async fn run() -> std::io::Result<()> {
     env_logger::from_env(Env::default().default_filter_or("info")).init();
 
-    HttpServer::new(|| App::new().wrap(Logger::default()).configure(routes::routes))
-        .bind("127.0.0.1:8088")?
-        .run()
-        .await
+    HttpServer::new(|| {
+        App::new()
+            .wrap(Logger::default())
+            .configure(routes::routes)
+            .wrap(middleware::NormalizePath)
+    })
+    .bind("127.0.0.1:8088")?
+    .run()
+    .await
 }

--- a/src/app/routes.rs
+++ b/src/app/routes.rs
@@ -6,9 +6,9 @@ pub(crate) fn routes(app: &mut web::ServiceConfig) {
     app.service(
         web::scope("api").service(
             web::scope("articles")
-                .service(web::resource("").route(web::get().to(articles_handler::index)))
+                .service(web::resource("/").route(web::get().to(articles_handler::index)))
                 .service(
-                    web::resource("{author}/{title}")
+                    web::resource("{author}/{title}/")
                         .route(web::get().to(articles_handler::get_article)),
                 ),
         ),


### PR DESCRIPTION
- Use `middleware::NormalizePath`
- Add readme

Middlewareによりパスの正規化を行う。
ルーティングにはTrailingSlashありで定義する。

Closes #8 