### PR TITLE
Future cannot be sent between threads safely.

### DIFF
--- a/src/app/v1/users/handler/users_handler.rs
+++ b/src/app/v1/users/handler/users_handler.rs
@@ -1,10 +1,9 @@
-use std::ops::Deref;
-
 use actix_web::{get, post, web, HttpResponse, Responder};
 use slog::{crit, o};
 
 use crate::app::error::AppError;
 use crate::app::v1::users::dto::post_users_request::PostUsersRequest;
+use crate::app::v1::users::repository::user_repository::UserRepositoryImpl;
 use crate::app::v1::users::service::user_service::{UserService, UserServiceImpl};
 use crate::app::AppState;
 
@@ -16,7 +15,8 @@ pub(crate) async fn create(
     let log = state.log.new(o!("handler" => "user_handler.create"));
     let email = request.email.as_str();
 
-    let user_service = UserServiceImpl::new(state.deref());
+    let user_repository = UserRepositoryImpl::new(&state.pool);
+    let user_service = UserServiceImpl::new(&user_repository, log.clone());
     user_service
         .create(email, request.name.as_str())
         .await
@@ -41,7 +41,9 @@ pub(crate) async fn find_by_id(
 ) -> Result<impl Responder, AppError> {
     let log = state.log.new(o!("handler" => "user_handler.find_by_id"));
 
-    let user_service = UserServiceImpl::new(state.deref());
+    let user_repository = UserRepositoryImpl::new(&state.pool);
+    let user_service = UserServiceImpl::new(&user_repository, log.clone());
+
     let user = user_service.find_by_id(path.0).await.map_err(|err| {
         let sub_log = log.new(o!("cause" => err.to_string()));
         crit!(sub_log, "Failed to find user");

--- a/src/app/v1/users/service/user_service.rs
+++ b/src/app/v1/users/service/user_service.rs
@@ -4,8 +4,7 @@ use slog::{error, o, Logger};
 
 use crate::app::error::AppError;
 use crate::app::v1::users::model::user::User;
-use crate::app::v1::users::repository::user_repository::{UserRepository, UserRepositoryImpl};
-use crate::app::AppState;
+use crate::app::v1::users::repository::user_repository::UserRepository;
 
 #[async_trait]
 pub(crate) trait UserService {
@@ -15,15 +14,15 @@ pub(crate) trait UserService {
 }
 
 pub(crate) struct UserServiceImpl<'user_service> {
-    user_repository: UserRepositoryImpl<'user_service>,
+    user_repository: &'user_service dyn UserRepository,
     log: Logger,
 }
 
 impl UserServiceImpl<'_> {
-    pub(crate) fn new(state: &AppState) -> UserServiceImpl {
+    pub(crate) fn new(user_repository: &dyn UserRepository, log: Logger) -> UserServiceImpl {
         UserServiceImpl {
-            user_repository: UserRepositoryImpl::new(&state.pool),
-            log: state.log.new(o!("service"=>"UserServiceImpl")),
+            user_repository,
+            log: log.new(o!("service"=>"UserServiceImpl")),
         }
     }
 }


### PR DESCRIPTION
```
error: future cannot be sent between threads safely
  --> src/app/v1/users/service/user_service.rs:32:77
   |
32 |       async fn create(&self, email: &str, name: &str) -> Result<(), AppError> {
   |  _____________________________________________________________________________^
33 | |         let log = self.log.new(o!("function" => "create"));
34 | |
35 | |         let email_regex = Regex::new(
...  |
49 | |         Ok(())
50 | |     }
   | |_____^ future returned by `__create` is not `Send`
   |
   = help: the trait `std::marker::Sync` is not implemented for `dyn app::v1::users::repository::user_repository::UserRepository`
note: future is not `Send` as this value is used across an await
  --> src/app/v1/users/service/user_service.rs:45:9
   |
45 |           self.user_repository
   |           ^-------------------
   |           |
   |  _________has type `&dyn app::v1::users::repository::user_repository::UserRepository` which is not `Send`
   | |
46 | |             .create(email, name)
47 | |             .await
   | |__________________^ await occurs here, with `self.user_repository` maybe used later
48 |               .map_err(AppError::db_error)?;
   |                                            - `self.user_repository` is later dropped here
help: consider moving this into a `let` binding to create a shorter lived borrow
  --> src/app/v1/users/service/user_service.rs:45:9
   |
45 | /         self.user_repository
46 | |             .create(email, name)
   | |________________________________^
   = note: required for the cast to the object type `dyn core::future::future::Future<Output = std::result::Result<(), app::error::AppError>> + std::marker::Send`

error: future cannot be sent between threads safely
  --> src/app/v1/users/service/user_service.rs:52:67
   |
52 |       async fn find_by_id(&self, id: u64) -> Result<User, AppError> {
   |  ___________________________________________________________________^
53 | |         let user = self
54 | |             .user_repository
55 | |             .find_by_id(id)
...  |
58 | |         Ok(user)
59 | |     }
   | |_____^ future returned by `__find_by_id` is not `Send`
   |
   = help: the trait `std::marker::Sync` is not implemented for `dyn app::v1::users::repository::user_repository::UserRepository`
note: future is not `Send` as this value is used across an await
  --> src/app/v1/users/service/user_service.rs:53:20
   |
53 |            let user = self
   |   ____________________^
   |  |____________________|
   | ||
54 | ||             .user_repository
   | ||____________________________- has type `&dyn app::v1::users::repository::user_repository::UserRepository` which is not `Send`
55 | |              .find_by_id(id)
56 | |              .await
   | |___________________^ await occurs here, with `self
            .user_repository` maybe used later
57 |                .map_err(AppError::db_error)?;
   |                                             - `self
            .user_repository` is later dropped here
help: consider moving this into a `let` binding to create a shorter lived borrow
  --> src/app/v1/users/service/user_service.rs:53:20
   |
53 |           let user = self
   |  ____________________^
54 | |             .user_repository
55 | |             .find_by_id(id)
   | |___________________________^
   = note: required for the cast to the object type `dyn core::future::future::Future<Output = std::result::Result<app::v1::users::model::user::User, app::error::AppError>> + std::marker::Send`

error: future cannot be sent between threads safely
  --> src/app/v1/users/service/user_service.rs:61:74
   |
61 |       async fn find_by_email(&self, email: &str) -> Result<User, AppError> {
   |  __________________________________________________________________________^
62 | |         let user = self
63 | |             .user_repository
64 | |             .find_by_email(email)
...  |
67 | |         Ok(user)
68 | |     }
   | |_____^ future returned by `__find_by_email` is not `Send`
   |
   = help: the trait `std::marker::Sync` is not implemented for `dyn app::v1::users::repository::user_repository::UserRepository`
note: future is not `Send` as this value is used across an await
  --> src/app/v1/users/service/user_service.rs:62:20
   |
62 |            let user = self
   |   ____________________^
   |  |____________________|
   | ||
63 | ||             .user_repository
   | ||____________________________- has type `&dyn app::v1::users::repository::user_repository::UserRepository` which is not `Send`
64 | |              .find_by_email(email)
65 | |              .await
   | |___________________^ await occurs here, with `self
            .user_repository` maybe used later
66 |                .map_err(AppError::db_error)?;
   |                                             - `self
            .user_repository` is later dropped here
help: consider moving this into a `let` binding to create a shorter lived borrow
  --> src/app/v1/users/service/user_service.rs:62:20
   |
62 |           let user = self
   |  ____________________^
63 | |             .user_repository
64 | |             .find_by_email(email)
   | |_________________________________^
   = note: required for the cast to the object type `dyn core::future::future::Future<Output = std::result::Result<app::v1::users::model::user::User, app::error::AppError>> + std::marker::Send`

error: aborting due to 3 previous errors

error: could not compile `actix_web_sample`.

To learn more, run the command again with --verbose.

Process finished with exit code 101
```